### PR TITLE
Save multiple elements in a Stream

### DIFF
--- a/src/main/scala/org/virtuslab/unicorn/ids/services/BaseServices.scala
+++ b/src/main/scala/org/virtuslab/unicorn/ids/services/BaseServices.scala
@@ -147,7 +147,7 @@ trait BaseIdService[I <: BaseId, A <: WithId[I]] {
    * @return Sequence of ids
    */
   def saveAll(elems: Seq[A])(implicit session: Session): Seq[I] = session.withTransaction {
-    elems.map(elem => this.save(elem))
+    elems.toIndexedSeq map save
   }
 
 }

--- a/src/test/scala/org/virtuslab/unicorn/ids/services/UsersServiceTest.scala
+++ b/src/test/scala/org/virtuslab/unicorn/ids/services/UsersServiceTest.scala
@@ -54,6 +54,20 @@ class UsersServiceTest extends AppTest {
       userOpt.flatMap(_.id) shouldNot be(None)
   }
 
+  it should "save and query multiple users" in rollback {
+    implicit session =>
+    // setup
+      object UsersService extends UsersService
+      Users.ddl.create
+
+      val users = (Stream from 1 take 10) map (n => User(None, "test@email.com", "Krzysztof" + n, "Nowak"))
+      UsersService saveAll users
+      val newUsers = UsersService.findAll()
+      newUsers.size shouldEqual 10
+      newUsers.headOption map (_.firstName) shouldEqual Some("Krzysztof1")
+      newUsers.lastOption map (_.firstName) shouldEqual Some("Krzysztof10")
+  }
+
   it should "query existing user" in rollback {
     implicit session =>
     // setup


### PR DESCRIPTION
I noticed that when calling `saveAll` on a `Stream`, it doesn't actually materialize all the elements in the stream. This seems like the wrong behavior. You would expect all the elements to be saved within the transaction. Instead, the saves only happen when you access the elements of the resulting collection.

I fixed the issue by converting to an `IndexedSeq` in `saveAll` which forces all the elements to be computed.
