### PR TITLE
Patched for Slick 2.1.0-M1 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "unicorn"
 
 version := "0.5.0-RC1"
 
-scalaVersion := "2.10.3"
+scalaVersion := "2.10.4"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
@@ -13,7 +13,7 @@ resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repos
 resolvers += Resolver.typesafeRepo("releases")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick" % "2.0.0",
+  "com.typesafe.slick" %% "slick" % "2.1.0-M1",
   "com.typesafe.play" %% "play-slick" % "0.6.0.1",
   "org.scalatest" % "scalatest_2.10" % "2.0" % "test",
   "com.typesafe.play" %% "play-test" % "2.2.2" % "test",

--- a/src/main/scala/org/virtuslab/unicorn/ids/repositories/BaseIdRepository.scala
+++ b/src/main/scala/org/virtuslab/unicorn/ids/repositories/BaseIdRepository.scala
@@ -23,7 +23,7 @@ class BaseIdRepository[I <: BaseId, A <: WithId[I], T <: IdTable[I, A]](tableNam
    * @param session implicit session param for query
    * @return all elements of type A
    */
-  def findAll()(implicit session: Session): Seq[A] = query.list()
+  def findAll()(implicit session: Session): Seq[A] = query.list
 
   /**
    * Deletes all elements in table.
@@ -83,7 +83,7 @@ class BaseIdRepository[I <: BaseId, A <: WithId[I], T <: IdTable[I, A]](tableNam
    * @param session implicit session
    * @return Sequence of ids
    */
-  def allIds()(implicit session: Session): Seq[I] = allIdsQuery.list()
+  def allIds()(implicit session: Session): Seq[I] = allIdsQuery.list
 
   /**
    * Saves one element.

--- a/src/main/scala/org/virtuslab/unicorn/ids/repositories/BaseRepository.scala
+++ b/src/main/scala/org/virtuslab/unicorn/ids/repositories/BaseRepository.scala
@@ -16,7 +16,7 @@ abstract class BaseRepository[A, T <: Table[A]](val query: TableQuery[T]) {
    * @param session implicit session param for query
    * @return all elements of type A
    */
-  def findAll()(implicit session: Session): Seq[A] = query.list()
+  def findAll()(implicit session: Session): Seq[A] = query.list
 
   /**
    * Deletes all elements in table.

--- a/src/main/scala/org/virtuslab/unicorn/ids/repositories/JunctionRepository.scala
+++ b/src/main/scala/org/virtuslab/unicorn/ids/repositories/JunctionRepository.scala
@@ -81,7 +81,7 @@ trait JunctionRepository[A, B] extends JunctionQueries[A, B] {
    * @param session implicit session param for query
    * @return all elements of type (A, B)
    */
-  def findAll()(implicit session: Session): Seq[(A, B)] = Query(table).list()
+  def findAll()(implicit session: Session): Seq[(A, B)] = Query(table).list
 
   /**
    * Saves one element if it's not present in db already.
@@ -93,7 +93,7 @@ trait JunctionRepository[A, B] extends JunctionQueries[A, B] {
    */
   def save(a: A, b: B)(implicit session: Session) {
     getQuery(a, b)
-      .firstOption()
+      .firstOption
       .orElse(Some(table.insert((a, b))))
   }
 
@@ -101,13 +101,13 @@ trait JunctionRepository[A, B] extends JunctionQueries[A, B] {
    * @param a element to query by
    * @return all b values for given a
    */
-  def forA(a: A)(implicit session: Session): Seq[B] = getByAQuery(a).list()
+  def forA(a: A)(implicit session: Session): Seq[B] = getByAQuery(a).list
 
   /**
    * @param b element to query by
    * @return all a values for given b
    */
-  def forB(b: B)(implicit session: Session): Seq[A] = getByBQuery(b).list()
+  def forB(b: B)(implicit session: Session): Seq[A] = getByBQuery(b).list
 
   /**
    * Delete all rows with given a value.

--- a/src/test/scala/org/virtuslab/unicorn/ids/repositories/DictionaryRepositoryTest.scala
+++ b/src/test/scala/org/virtuslab/unicorn/ids/repositories/DictionaryRepositoryTest.scala
@@ -29,7 +29,7 @@ class DictionaryRepositoryTest extends AppTest {
         } yield dictionaryEntry.value
 
         override protected def exists(entry: DictionaryEntry)(implicit session: Session): Boolean =
-          findQuery(entry).firstOption().nonEmpty
+          findQuery(entry).firstOption.nonEmpty
       }
       dictQuery.ddl.create
 


### PR DESCRIPTION
Probably shouldn't be merged before 2.1.0 final is released, but it works and tests pass under both 2.1.0-M1 and 2.0.0.
