### PR TITLE
Cleanup junction repository

### DIFF
--- a/unicorn-core/src/main/scala/org/virtuslab/unicorn/Tables.scala
+++ b/unicorn-core/src/main/scala/org/virtuslab/unicorn/Tables.scala
@@ -1,7 +1,5 @@
 package org.virtuslab.unicorn
 
-import scala.slick.lifted.{ Column => SlickColumn }
-
 protected[unicorn] trait Tables extends TypeMappers {
   self: HasJdbcDriver with Identifiers =>
 
@@ -68,7 +66,7 @@ protected[unicorn] trait Tables extends TypeMappers {
      * instead of def * = colA ~ colB write def columns = colA -> colB
      * @return
      */
-    def columns: (SlickColumn[First], SlickColumn[Second])
+    def columns: (Column[First], Column[Second])
 
     final def * = (columns._1, columns._2)
 

--- a/unicorn-core/src/main/scala/org/virtuslab/unicorn/repositories/JunctionRepositories.scala
+++ b/unicorn-core/src/main/scala/org/virtuslab/unicorn/repositories/JunctionRepositories.scala
@@ -14,7 +14,8 @@ protected[unicorn] trait JunctionRepositories {
    */
   class JunctionRepository[First: BaseColumnType, Second: BaseColumnType, Table <: JunctionTable[First, Second]](val query: TableQuery[Table]) {
 
-    protected def findOneQueryFun(first: Column[First], second: Column[Second]) = query.filter(row => row.columns._1 === first && row.columns._2 === second)
+    protected def findOneQueryFun(first: Column[First], second: Column[Second]) =
+      query.filter(row => row.columns._1 === first && row.columns._2 === second)
 
     protected val findOneQueryCompiled = Compiled(findOneQueryFun _)
 
@@ -46,7 +47,8 @@ protected[unicorn] trait JunctionRepositories {
      * @param session implicit session
      * @return number of deleted elements (0 or 1)
      */
-    def delete(first: First, second: Second)(implicit session: Session): Int = findOneQueryCompiled((first, second)).delete
+    def delete(first: First, second: Second)(implicit session: Session): Int =
+      findOneQueryCompiled((first, second)).delete
 
     /**
      * Checks if element exists in database.
@@ -56,7 +58,8 @@ protected[unicorn] trait JunctionRepositories {
      * @param session implicit database session
      * @return true if element exists in database
      */
-    def exists(first: First, second: Second)(implicit session: Session): Boolean = existsQuery((first, second)).run
+    def exists(first: First, second: Second)(implicit session: Session): Boolean =
+      existsQuery((first, second)).run
 
     /**
      * @param session implicit session param for query

--- a/unicorn-core/src/test/scala/org/virtuslab/unicorn/repositories/JunctionRepositoryTest.scala
+++ b/unicorn-core/src/test/scala/org/virtuslab/unicorn/repositories/JunctionRepositoryTest.scala
@@ -4,11 +4,7 @@ import org.virtuslab.unicorn.TestUnicorn
 import TestUnicorn._
 import TestUnicorn.driver.simple._
 import org.virtuslab.unicorn.BaseTest
-import org.scalatest.BeforeAndAfterEach
 
-/**
- * Created by Łukasz Dubiel on 25.03.14.
- */
 class JunctionRepositoryTest extends BaseTest {
 
   behavior of classOf[JunctionRepository[_, _, _]].getSimpleName


### PR DESCRIPTION
Move to Slick 2.0 with full test coverage (now we could assume it's works, be able to make refactoring safe).

It's break API (use two parameters instead tuples, but it could be easy solved using eta-expansion on tupled method
Previews

```
def exists(elem: (First, Second))(implicit session: Session): Boolean
```

now is 

```
def exists(first: First, second: Second)(implicit session: Session): Boolean
```

We could move from second to first using `(repository.exists _).tupled()`.
As it is breaking change it should be included in next minor release. 
Also we should add it in migration guide. 
