### PR TITLE
Refactor tests to use properties matchers

### DIFF
--- a/unicorn-core/src/test/scala/org/virtuslab/unicorn/repositories/DictionaryRepositoryTest.scala
+++ b/unicorn-core/src/test/scala/org/virtuslab/unicorn/repositories/DictionaryRepositoryTest.scala
@@ -53,7 +53,7 @@ class DictionaryRepositoryTest extends BaseTest[Long] with LongTestUnicorn {
       DictionaryRepository.deleteAll()
 
       // then
-      DictionaryRepository.findAll() shouldBe 'empty
+      DictionaryRepository.findAll() shouldBe empty
   }
 
 }

--- a/unicorn-play/src/test/scala/org/virtuslab/unicorn/BasePlayTest.scala
+++ b/unicorn-play/src/test/scala/org/virtuslab/unicorn/BasePlayTest.scala
@@ -6,6 +6,7 @@ import play.api.test.FakeApplication
 
 trait BasePlayTest
     extends FlatSpecLike
+    with OptionValues
     with Matchers
     with BeforeAndAfterEach
     with RollbackHelper[Long]

--- a/unicorn-play/src/test/scala/org/virtuslab/unicorn/PlayCompanionTest.scala
+++ b/unicorn-play/src/test/scala/org/virtuslab/unicorn/PlayCompanionTest.scala
@@ -32,7 +32,7 @@ class PlayCompanionTest extends BasePlayTest {
   it should "have working implicit query string binder" in {
     val qsb = implicitly[QueryStringBindable[UserId]]
     val userId = UserId(123)
-    qsb.bind("id", Map("id" -> Seq("123"))).get shouldEqual Right(userId)
+    qsb.bind("id", Map("id" -> Seq("123"))).value shouldEqual Right(userId)
     qsb.unbind("id", userId) shouldEqual "id=123"
   }
 
@@ -49,7 +49,7 @@ class PlayCompanionTest extends BasePlayTest {
       (JsPath \ "name").read[String]
     )(User.apply _)
 
-    jsonUser.validate[User].get.id shouldEqual user.id
+    jsonUser.validate[User].get shouldEqual user
 
     // Writes
 
@@ -76,7 +76,7 @@ class PlayCompanionTest extends BasePlayTest {
     )
 
     // Reads
-    userForm.bind(userMap).get.id shouldEqual user.id
+    userForm.bind(userMap).get shouldEqual user
 
     // Writes - just check if it works without errors
     userForm.fill(user)


### PR DESCRIPTION
Properties matchers are really nice way to check values of fields in case classes. For more info, see [ScalaTest documentation](http://www.scalatest.org/user_guide/using_matchers#checkingArbitraryProperties).