### PR TITLE
Move common methods of repositories to one place

### DIFF
--- a/unicorn-core/src/main/scala/org/virtuslab/unicorn/repositories/JunctionRepositories.scala
+++ b/unicorn-core/src/main/scala/org/virtuslab/unicorn/repositories/JunctionRepositories.scala
@@ -3,7 +3,7 @@ package org.virtuslab.unicorn.repositories
 import org.virtuslab.unicorn.{ HasJdbcDriver, Tables, Identifiers }
 
 protected[unicorn] trait JunctionRepositories[Underlying] {
-  self: HasJdbcDriver with Tables[Underlying] with Identifiers[Underlying] =>
+  self: HasJdbcDriver with Tables[Underlying] with Identifiers[Underlying] with Repositories[Underlying] =>
 
   import driver.simple.{ Table => _, _ }
 
@@ -12,7 +12,8 @@ protected[unicorn] trait JunctionRepositories[Underlying] {
    * @tparam First type of one entity
    * @tparam Second type of other entity
    */
-  class JunctionRepository[First: BaseColumnType, Second: BaseColumnType, Table <: JunctionTable[First, Second]](val query: TableQuery[Table]) {
+  class JunctionRepository[First: BaseColumnType, Second: BaseColumnType, Table <: JunctionTable[First, Second]](val query: TableQuery[Table])
+      extends CommonRepositoryMethods[(First, Second), Table](query) {
 
     protected def findOneQueryFun(first: Column[First], second: Column[Second]) =
       query.filter(row => row.columns._1 === first && row.columns._2 === second)
@@ -60,12 +61,6 @@ protected[unicorn] trait JunctionRepositories[Underlying] {
      */
     def exists(first: First, second: Second)(implicit session: Session): Boolean =
       existsQuery((first, second)).run
-
-    /**
-     * @param session implicit session param for query
-     * @return all elements of type (First, Second)
-     */
-    def findAll()(implicit session: Session): Seq[(First, Second)] = query.run
 
     /**
      * Saves one element if it's not present in db already.

--- a/unicorn-core/src/main/scala/org/virtuslab/unicorn/repositories/Repositories.scala
+++ b/unicorn-core/src/main/scala/org/virtuslab/unicorn/repositories/Repositories.scala
@@ -10,13 +10,9 @@ protected[unicorn] trait Repositories[Underlying]
   import driver.simple._
 
   /**
-   * Base for services for entities that have no type-safe id created - for example join tables.
-   *
-   * @tparam Entity type of entity
-   * @tparam T type of table
-   * @param query base table query
+   * Implementation detail - common methods for all repositories.
    */
-  abstract class BaseRepository[Entity, T <: Table[Entity]](val query: TableQuery[T]) {
+  private[repositories] abstract class CommonRepositoryMethods[Entity, T <: Table[Entity]](query: TableQuery[T]) {
 
     /**
      * @param session implicit session param for query
@@ -30,6 +26,33 @@ protected[unicorn] trait Repositories[Underlying]
      * @return number of deleted elements
      */
     def deleteAll()(implicit session: Session): Int = query.delete
+
+    /**
+     * Creates table definition in database.
+     *
+     * @param session implicit database session
+     */
+    def create()(implicit session: Session): Unit =
+      query.ddl.create
+
+    /**
+     * Drops table definition from database.
+     *
+     * @param session implicit database session
+     */
+    def drop()(implicit session: Session): Unit =
+      query.ddl.drop
+  }
+
+  /**
+   * Base for services for entities that have no type-safe id created - for example join tables.
+   *
+   * @tparam Entity type of entity
+   * @tparam T type of table
+   * @param query base table query
+   */
+  abstract class BaseRepository[Entity, T <: Table[Entity]](val query: TableQuery[T])
+      extends CommonRepositoryMethods[Entity, T](query) {
 
     /**
      * Saves one element. Warning - if element already exist, it's not updated.


### PR DESCRIPTION
findAll(), deleteAll(), create() and drop() moved to one abstract class
all repos now extends.