### PR TITLE
Make UnicornPlay dbConfig lazy

### DIFF
--- a/unicorn-play/src/main/scala/org/virtuslab/unicorn/UnicornPlay.scala
+++ b/unicorn-play/src/main/scala/org/virtuslab/unicorn/UnicornPlay.scala
@@ -13,7 +13,7 @@ trait UnicornPlayLike[Underlying]
     with PlayIdentifiers[Underlying]
     with HasJdbcDriver {
 
-  private val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+  private lazy val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
 
   def underlyingFormatter: Formatter[Underlying]
 


### PR DESCRIPTION
Testing components that depend on UnicornPlay without a Play application
started results in a RuntimeException

Caused by: java.lang.RuntimeException: There is no started application
 at scala.sys.package$.error(package.scala:27)
 at play.api.Play$$anonfun$current$1.apply(Play.scala:71)
 at play.api.Play$$anonfun$current$1.apply(Play.scala:71)
 at scala.Option.getOrElse(Option.scala:121)
 at play.api.Play$.current(Play.scala:71)
 at org.virtuslab.unicorn.UnicornPlayLike$class.$init$(UnicornPlay.scala:16)
 at org.virtuslab.unicorn.UnicornPlay.<init>(UnicornPlay.scala:37)
 at org.virtuslab.unicorn.LongUnicornPlay$.<init>(UnicornPlay.scala:39)
 at org.virtuslab.unicorn.LongUnicornPlay$.<clinit>(UnicornPlay.scala)

Making this `val` a `lazy val` resolves this issue.