### PR TITLE
Pass driver into UnicornPlay

### DIFF
--- a/unicorn-play/src/main/scala/org/virtuslab/unicorn/UnicornPlay.scala
+++ b/unicorn-play/src/main/scala/org/virtuslab/unicorn/UnicornPlay.scala
@@ -13,8 +13,6 @@ trait UnicornPlayLike[Underlying]
     with PlayIdentifiers[Underlying]
     with HasJdbcDriver {
 
-  private lazy val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
-
   def underlyingFormatter: Formatter[Underlying]
 
   def underlyingFormat: Format[Underlying]
@@ -25,15 +23,21 @@ trait UnicornPlayLike[Underlying]
 
   override type IdCompanion[Id <: BaseId] = PlayCompanion[Id]
 
-  override lazy val driver = dbConfig.driver
-
 }
 
-class UnicornPlay[Underlying](implicit val underlyingFormatter: Formatter[Underlying],
+class UnicornPlay[Underlying](override val driver: JdbcProfile)(implicit val underlyingFormatter: Formatter[Underlying],
   val underlyingFormat: Format[Underlying],
   val underlyingQueryStringBinder: QueryStringBindable[Underlying],
   val underlyingPathBinder: PathBindable[Underlying],
   val ordering: Ordering[Underlying])
     extends UnicornPlayLike[Underlying]
 
-object LongUnicornPlay extends UnicornPlay[Long]
+object CurrentPlay {
+
+  lazy val dbConfig = DatabaseConfigProvider.get[JdbcProfile](Play.current)
+
+  lazy val driver = dbConfig.driver
+
+}
+
+object LongUnicornPlay extends UnicornPlay[Long](CurrentPlay.driver)

--- a/unicorn-play/src/test/scala/org/virtuslab/unicorn/StringPlayUnicorn.scala
+++ b/unicorn-play/src/test/scala/org/virtuslab/unicorn/StringPlayUnicorn.scala
@@ -3,7 +3,7 @@ package org.virtuslab.unicorn
 import play.api.data.format.Formats._
 import slick.lifted.{ ProvenShape, Tag => SlickTag }
 
-object StringPlayUnicorn extends UnicornPlay[String]
+object StringPlayUnicorn extends UnicornPlay[String](CurrentPlay.driver)
 
 import StringPlayUnicorn._
 import StringPlayUnicorn.driver.api._


### PR DESCRIPTION
Having issues with the references to Play.current inside UnicornPlay when trying to use eagerly bound dependencies that try to instantiate UnicornPlay before the Play.current application has been started.  This leads to runtime exceptions.

Here is my proposed solution, comments welcome.
