### PR TITLE
Added support for Slick 3.2.x and cross compilation for Scala 2.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ jdk:
   - oraclejdk8
 
 sbt_args: -no-colors
-script: sbt ++$TRAVIS_SCALA_VERSION scalastyle clean coverage test unidoc
+script: sbt scalastyle clean coverage test unidoc "project unicorn-core" +test
 after_success: sbt coveralls

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,19 @@
-import scoverage.ScoverageSbtPlugin.ScoverageKeys
 
 val `unicorn-core` = project
-  .settings(Settings.common: _*)
+  .settings(Settings.core: _*)
   .settings(
     libraryDependencies ++= Dependencies.core(scalaVersion.value),
     // cannot be higher due to tests not able to reproduce abnormal DB behavior
-    ScoverageKeys.coverageMinimum := 100,
+    coverageMinimum := 100,
     (scalastyleConfig in Test) := file("scalastyle-test-config.xml")
   )
 
 val `unicorn-play` = project
-  .settings(Settings.common: _*)
+  .settings(Settings.play: _*)
   .settings(
     libraryDependencies ++= Dependencies.core(scalaVersion.value),
     libraryDependencies ++= Dependencies.play,
-    ScoverageKeys.coverageMinimum := 100,
+    coverageMinimum := 100,
     (scalastyleConfig in Test) := file("scalastyle-test-config.xml")
   )
   .dependsOn(`unicorn-core` % Settings.alsoOnTest)
@@ -23,7 +22,7 @@ val unicorn = project
   .in(file("."))
   .aggregate(`unicorn-core`, `unicorn-play`)
   .dependsOn(`unicorn-core`, `unicorn-play`)
-  .settings(Settings.core: _*)
+  .settings(Settings.parent: _*)
   .settings(unidocSettings: _*)
   .settings(
     name := "unicorn"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,13 +3,13 @@ import sbt._
 object Dependencies {
 
   def mainCore(scalaVersion: String) = Seq(
-    "com.typesafe.slick" %% "slick" % "3.1.0",
+    "com.typesafe.slick" %% "slick" % pickVersion(scalaVersion, ver211 = "3.1.1", ver212 = "3.2.0-M2"),
     "joda-time" % "joda-time" % "2.8.1",
     "org.joda" % "joda-convert" % "1.7"
   )
 
   val testCore = Seq(
-    "org.scalatest" %% "scalatest" % "2.2.5" % "test",
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "com.h2database" % "h2" % "1.4.187" % "test",
     "ch.qos.logback" % "logback-classic" % "1.1.3" % "test"
   )
@@ -26,4 +26,9 @@ object Dependencies {
 
   val play = mainPlay ++ testPlay
 
+  def pickVersion(scalaVersion: String, ver211: String, ver212: String) = CrossVersion.partialVersion(scalaVersion) match {
+    case Some((_, 11)) => ver211
+    case Some((_, 12)) => ver212
+    case _ => throw new IllegalStateException(s"Unsupported version passsed: ${scalaVersion}")
+  }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,19 +1,24 @@
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.pgp.PgpKeys
 import sbtrelease.ReleasePlugin.autoImport._
-import scoverage.ScoverageSbtPlugin._
 import sbt.Keys._
 import sbt._
 import xerial.sbt.Sonatype
 
 object Settings {
 
+  val scala_2_11 = "2.11.8"
+  val scala_2_12 = "2.12.1"
+
   val alsoOnTest = "compile->compile;test->test"
 
   // settings for ALL modules, including parent
-  val core = Seq(
+  val common = Seq(
     organization := "org.virtuslab",
-    scalaVersion := "2.11.8",
+
+    parallelExecution in Test := false,
+    testOptions in Test += Tests.Argument("-oDF"),
+
     releasePublishArtifactsAction := PgpKeys.publishSigned.value,
       pomExtra := <url>https://github.com/VirtusLab/unicorn</url>
       <licenses>
@@ -42,12 +47,22 @@ object Settings {
   ) ++
     Sonatype.sonatypeSettings
 
+  val core = common ++ Seq(
+    scalaVersion := scala_2_11,
+    crossScalaVersions := Seq(scala_2_11, scala_2_12),
+    releaseCrossBuild := true
+  )
+
+  val play = common ++ Seq(
+    scalaVersion := scala_2_11
+  )
+
   // common settings for play and core modules
-  val common = core ++ Seq(
+  val parent = common ++ Seq(
+    scalaVersion := scala_2_11,
     resolvers += Resolver.typesafeRepo("releases"),
     resolvers += Resolver.sonatypeRepo("releases"),
     resolvers += Resolver.sonatypeRepo("snapshots"),
-    parallelExecution in Test := false,
     scalacOptions ++= Seq(
       "-feature",
       "-deprecation",
@@ -56,6 +71,6 @@ object Settings {
       "-Xfatal-warnings"
     ),
     updateOptions := updateOptions.value.withCachedResolution(true),
-    ScoverageKeys.coverageFailOnMinimum := true
+    scoverage.ScoverageKeys.coverageFailOnMinimum := true
   ) ++ SbtScalariform.scalariformSettings
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 /* ************ */
 /* Code quality */
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 
@@ -21,7 +21,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0.BETA1")
 

--- a/unicorn-core/src/main/scala-2.11/org/virtuslab/unicorn/SlickExports.scala
+++ b/unicorn-core/src/main/scala-2.11/org/virtuslab/unicorn/SlickExports.scala
@@ -1,0 +1,22 @@
+package org.virtuslab.unicorn
+
+import slick.profile.BasicProfile
+
+/**
+  * This remapping of types handle differences between Slick 3.1.x and 3.2.x.
+  *
+  * This is not really connected that much but what we do here is we group bind together:
+  * - Scala 2.11.x with Slick 3.1.x
+  * - Scala 2.12.x with Slick 3.2.x
+  *
+  * The only reason for this is that:
+  * - Play doesn't support yet Scala 2.12
+  * - play-slick doesn't support neither Scala 2.12 nor Slick 3.2
+  *
+  * So in theory we could have Slick 3.2.x for both Scala 2.11.x and 2.12.x but play-slick seems to be extremely slow
+  * in adapting changes (including even things like accepting PRs). It may be worth to think if we really need play-slick at all.
+  */
+object SlickExports {
+  type JdbcProfile = slick.driver.JdbcProfile
+  type DatabaseConfig[P <: BasicProfile] = slick.backend.DatabaseConfig[P]
+}

--- a/unicorn-core/src/main/scala-2.12/org/virtuslab/unicorn/SlickExports.scala
+++ b/unicorn-core/src/main/scala-2.12/org/virtuslab/unicorn/SlickExports.scala
@@ -1,0 +1,22 @@
+package org.virtuslab.unicorn
+
+import slick.basic.BasicProfile
+
+/**
+  * This remapping of types handle differences between Slick 3.1.x and 3.2.x.
+  *
+  * This is not really connected that much but what we do here is we group bind together:
+  * - Scala 2.11.x with Slick 3.1.x
+  * - Scala 2.12.x with Slick 3.2.x
+  *
+  * The only reason for this is that:
+  * - Play doesn't support yet Scala 2.12
+  * - play-slick doesn't support neither Scala 2.12 nor Slick 3.2
+  *
+  * So in theory we could have Slick 3.2.x for both Scala 2.11.x and 2.12.x but play-slick seems to be extremely slow
+  * in adapting changes (including even things like accepting PRs). It may be worth to think if we really need play-slick at all.
+  */
+object SlickExports {
+  type JdbcProfile = slick.jdbc.JdbcProfile
+  type DatabaseConfig[P <: BasicProfile] = slick.basic.DatabaseConfig[P]
+}

--- a/unicorn-core/src/main/scala/org/virtuslab/unicorn/Unicorn.scala
+++ b/unicorn-core/src/main/scala/org/virtuslab/unicorn/Unicorn.scala
@@ -1,7 +1,7 @@
 package org.virtuslab.unicorn
 
 import org.virtuslab.unicorn.repositories.Repositories
-import slick.driver.JdbcProfile
+import org.virtuslab.unicorn.SlickExports.JdbcProfile
 
 import scala.language.higherKinds
 

--- a/unicorn-core/src/test/resources/logback.xml
+++ b/unicorn-core/src/test/resources/logback.xml
@@ -5,6 +5,12 @@
         </encoder>
     </appender>
 
+
+    <logger name="slick.backend" level="INFO" />
+    <logger name="slick.jdbc.JdbcBackend.benchmark" level="DEBUG" />
+    <logger name="slick.jdbc.JdbcBackend.statement" level="DEBUG" />
+    <logger name="slick.jdbc.StatementInvoker.result" level="DEBUG" />
+    <logger name="slick.jdbc.JdbcBackend.parameter" level="DEBUG" />
     <root level="info">
         <appender-ref ref="STDOUT" />
     </root>

--- a/unicorn-play/src/test/scala/org/virtuslab/unicorn/BasePlayTest.scala
+++ b/unicorn-play/src/test/scala/org/virtuslab/unicorn/BasePlayTest.scala
@@ -36,7 +36,7 @@ trait BasePlayTest
 
   import unicorn.driver.api._
 
-  override protected def beforeEach(data: TestData): Unit = {
+  override protected def beforeEach(): Unit = {
     DB.run(sqlu"""DROP ALL OBJECTS""")
     super.beforeEach()
   }

--- a/unicorn-play/src/test/scala/org/virtuslab/unicorn/StringPlayUnicorn.scala
+++ b/unicorn-play/src/test/scala/org/virtuslab/unicorn/StringPlayUnicorn.scala
@@ -1,8 +1,8 @@
 package org.virtuslab.unicorn
 
 import com.google.inject.{ Inject, Singleton }
-import slick.backend.DatabaseConfig
-import slick.driver.JdbcProfile
+import org.virtuslab.unicorn.SlickExports.JdbcProfile
+import org.virtuslab.unicorn.SlickExports.DatabaseConfig
 import slick.lifted.{ ProvenShape, Tag => SlickTag }
 import play.api.data.format.Formats._
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.1-SNAPSHOT"
+version in ThisBuild := "1.2.0-SNAPSHOT"


### PR DESCRIPTION
Only uniorn-core is build againt 2.12.x and Slick 3.2 (unicorn-play depends on play-slick and its terribly slow in adapting new versions).

Perhaps also this should target another branch